### PR TITLE
fix: layout blog and company

### DIFF
--- a/app/public/wp-content/themes/mooms_dev/resources/styles/theme/blocks/_service.scss
+++ b/app/public/wp-content/themes/mooms_dev/resources/styles/theme/blocks/_service.scss
@@ -2,7 +2,7 @@
 @use "../utilities/mixin.scss" as *;
 
 .block-service {
-    --gap: 3rem;
+    --gap: -1rem;
 
     &.reversed {
         .inner {
@@ -32,9 +32,11 @@
             gap: 2rem;
         }
         .name {
-            font-size: clamp(1.8rem, 2.5vw, 3rem);
+            padding: 2rem 0;
             font-weight: 700;
-            line-height: 2.2;
+            line-height: 1.4;
+
+            @include resFont(1.8, 3);
         }
         .desc {
             line-height: 1.8;
@@ -51,6 +53,7 @@
         .services-list {
             max-width: 100%;
             flex: 1 1 100%;
+            margin-bottom: 3rem;
         }
     }
 }

--- a/app/public/wp-content/themes/mooms_dev/resources/styles/theme/components/_section.scss
+++ b/app/public/wp-content/themes/mooms_dev/resources/styles/theme/components/_section.scss
@@ -109,21 +109,25 @@ select.wpcf7-form-control {
 }
 
 h3.title {
-    font-size: clamp(2.2rem, 2.5vw, 3rem);
+    margin-bottom: 2rem;
     font-weight: 700;
-    line-height: 2.2;
+    line-height: 1.4;
+
+    @include resFont(2.2, 3);
 }
 
 h2.block-title {
-    font-size: clamp(3rem, 2.5vw, 4.6rem);
     line-height: 2.2;
     font-weight: 700;
+
+    @include resFont(3, 4.6);
 }
 .block-desc {
-    font-size: clamp(1.4rem, 2.5vw, 1.6rem);
     font-weight: 400;
     line-height: 2;
     letter-spacing: 0.04em;
+
+    @include resFont(1.4, 1.6);
 }
 .btn-url {
     --mainColor: #{$primaryColor};
@@ -187,9 +191,6 @@ h2.block-title {
             }
         }
         }
-    }
-    @include maxWidth($md) {
-        padding: 1.8rem 8.2rem;
     }
 
     & ._circle {
@@ -352,6 +353,57 @@ h2.block-title {
         &:hover ._label {
             color: #fff;
         }
+        }
+    }
+
+    @include maxWidth($md) {
+        padding: 1.8rem 8.2rem;
+
+        &:not(.not-label) {
+            ._icon {
+                .mm-svg {
+                    opacity: 1;
+                    animation: none;
+                    @include iconify-mask("guidance:left-arrow", 2rem, 2rem, $primaryColor);
+                }
+
+                &::before {
+                    transform: translate(-50%, -50%) scale(0);
+                }
+
+                &::after {
+                    background-color: #fff;
+                    transform: translate(-50%, -50%) scale(1);
+                }
+            }
+
+            ._label {
+                color: #fff;
+            }
+
+            ._circle::before {
+                transform: scale(1);
+                background-color: $primaryColor;
+            }
+        }
+
+        &.not-label {
+            ._icon {
+                &::before,
+                &::after {
+                width: 2rem;
+                height: 2rem;
+                transform: translate(-50%, -50%) scale(2);
+                background-color: $primaryColor;
+                }
+
+                .mm-svg {
+                opacity: 1;
+                animation: none;
+                width: 2rem;
+                height: 2rem;
+                }
+            }
         }
     }
 }

--- a/app/public/wp-content/themes/mooms_dev/resources/styles/theme/layout/_general.scss
+++ b/app/public/wp-content/themes/mooms_dev/resources/styles/theme/layout/_general.scss
@@ -158,8 +158,7 @@ p:empty {
 }
 
 .full-width {
-  width: calc(100vw - 3px);
-  // width: 100vw;
+  width: 100vw;
   position: relative;
   left: 50%;
   right: 50%;

--- a/app/public/wp-content/themes/mooms_dev/resources/styles/theme/pages/_single.scss
+++ b/app/public/wp-content/themes/mooms_dev/resources/styles/theme/pages/_single.scss
@@ -1,12 +1,17 @@
 @use "../utilities/variables.scss" as *;
 @use "../utilities/mixin.scss" as *;
 
+
+.breadcrumb-top {
+  padding-top: 6rem;
+}
+
 nav.rank-math-breadcrumb {
   a {
     width: fit-content;
     display: inline-block;
-    font-size: clamp(1.3rem, 5vw, 1.4rem);
     font-weight: 600;
+    margin-top: 0;
     color: $textColor;
     text-decoration: none;
     text-decoration: underline;
@@ -16,11 +21,14 @@ nav.rank-math-breadcrumb {
     transition: text-decoration-color 0.2s ease-out;
     transition: text-decoration-color 0.2s ease-out,
       -webkit-text-decoration-color 0.2s ease-out;
+
+    @include resFont(1.3, 1.4);
+
     &::after {
       content: "";
       display: block;
       position: relative;
-      bottom: 0.5rem;
+      bottom: 0rem;
       width: 100%;
       height: 1px;
       background: linear-gradient(0deg, #70635f, #70635f) no-repeat right bottom /
@@ -28,6 +36,7 @@ nav.rank-math-breadcrumb {
       background-size: 0 1px;
       transition: background-size 0.3s ease-out;
     }
+
     &:hover::after {
       background-size: 100% 1px;
       background-position-x: left;
@@ -35,9 +44,10 @@ nav.rank-math-breadcrumb {
   }
 
   .last {
-    font-size: clamp(1.3rem, 5vw, 1.4rem);
     font-weight: 700;
     color: $primaryColor;
+
+    @include resFont(1.3, 1.4);
   }
 }
 
@@ -45,21 +55,32 @@ h1.page-title {
   margin-top: 1.25vw;
   font-style: normal;
   font-weight: 600;
-  font-size: clamp(3rem, 5vw, 5.8rem);
   line-height: 1.5;
   letter-spacing: 0.06em;
   color: #251e1c;
+
+  @include resFont(3, 5.8);
 }
 
 .page-header {
-  padding: clamp(3rem, 5vw, 7rem) 0;
-  margin-bottom: clamp(3rem, 5vw, 10rem);
+  padding: 7rem 0;
+  margin-bottom: 10rem;
+
+  @include maxWidth($md) {
+    padding: 3rem 0;
+    margin-bottom: 3rem;
+  }
 }
 
 .head-parent-page {
   // page thumbnail in parent page
   .page-thumbnail {
-    margin-bottom: clamp(3rem, 5vw, 5rem);
+    margin-bottom: 5rem;
+
+    @include maxWidth($md) {
+      margin-bottom: 3rem;
+    }
+
   }
 
   .page-excerpt {
@@ -69,10 +90,12 @@ h1.page-title {
 
 .head-child-page {
   position: relative;
+  margin-top: 1.5rem;
 
   @include maxWidth($md) {
     display: flex;
     flex-wrap: wrap;
+    margin-top: 0;
 
     .page-thumbnail {
       margin-bottom: 3rem;
@@ -82,8 +105,7 @@ h1.page-title {
   }
 
   .page-title-breadcrumb {
-    padding: clamp(3rem, 5vw, 8rem) clamp(5rem, 5vw, 10rem)
-      clamp(5rem, 5vw, 10rem) clamp(3rem, 5vw, 5rem);
+    padding: 6rem 6rem 6rem 3rem;
     position: absolute;
     bottom: 0;
     left: 0;
@@ -99,6 +121,14 @@ h1.page-title {
       min-width: 100%;
       order: 1;
     }
+  }
+}
+
+.page-content {
+  padding-top: 6rem;
+
+  @include maxWidth($md) {
+    padding-top: 0;
   }
 }
 
@@ -125,25 +155,28 @@ h1.page-title {
   }
 
   .parent-page {
-    // padding-bottom: clamp(3rem, 5vw, 5rem);
-    padding: clamp(3rem, 5vw, 8rem) clamp(5rem, 5vw, 10rem)
-      clamp(3rem, 5vw, 5rem) clamp(3rem, 5vw, 5rem);
+    padding: 6rem 6rem 6rem 3rem;
     border-bottom: 2px solid rgba(0, 0, 0, 0.1);
+
+    @include maxWidth($md) {
+      padding: 3rem 5rem 3rem 3rem;
+    }
 
     .parent-link {
       position: relative;
       display: inline-block;
-      font-size: clamp(2rem, 5vw, 2.4rem);
       font-weight: $bold;
       letter-spacing: 0.25px;
       color: $textColor;
       transition: all 0.3s ease-out;
 
+      @include resFont(2, 2.4);
+
       &::after {
         content: "";
         display: block;
         position: relative;
-        bottom: 0.5rem;
+        bottom: -0.5rem;
         width: 100%;
         height: 1.8px;
         background: linear-gradient(0deg, $textColor, $textColor) no-repeat
@@ -161,8 +194,11 @@ h1.page-title {
     }
   }
   .children-page {
-    padding: clamp(3rem, 5vw, 5rem) clamp(5rem, 5vw, 10rem)
-      clamp(5rem, 5vw, 10rem) clamp(3rem, 5vw, 5rem);
+    padding: 5rem 3rem;
+
+    @include maxWidth($md) {
+      padding: 3rem 5rem 5rem 3rem;
+    }
 
     ul {
       @include ulReset;
@@ -170,11 +206,13 @@ h1.page-title {
         a {
           padding: 1.8rem 0;
           display: block;
-          font-size: clamp(1.6rem, 5vw, 1.8rem);
           font-weight: 600;
           color: $textColor;
           text-decoration: none;
           transition: color 0.3s ease-out;
+
+          @include resFont(1.6, 1.8);
+
           &:hover {
             color: $primaryColor;
           }
@@ -223,8 +261,7 @@ h1.page-title {
   }
 
   .page-content {
-    padding: clamp(3rem, 5vw, 8rem) clamp(5rem, 5vw, 10rem)
-      clamp(5rem, 5vw, 10rem) clamp(3rem, 5vw, 10rem);
+    padding: 8rem 10rem 10rem 10rem;
     max-width: 80%;
     flex: 1 1 80%;
     border-left: 2px solid rgba(0, 0, 0, 0.1);
@@ -244,15 +281,24 @@ h1.page-title {
 }
 
 .child-pages {
-  margin-top: clamp(7rem, 5vw, 10rem);
-  padding: clamp(7rem, 5vw, 10rem) 0;
+  margin-top: 10rem;
+  padding: 10rem 0;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
+
+  @include maxWidth($md) {
+    margin-top: 7rem;
+    padding: 7rem 0;
+  }
 
   ul {
     @include ulReset;
 
     li.child-page {
-      margin-bottom: clamp(6rem, 10vw, 15rem);
+      margin-bottom: 15rem;
+
+      @include maxWidth($md) {
+        margin-bottom: 6rem;
+      }
 
       .inner {
         position: relative;
@@ -318,5 +364,33 @@ h1.page-title {
         }
       }
     }
+  }
+}
+
+.aiot-header {
+  margin-bottom: 2rem;
+}
+
+.aiot-content {
+  h3.wp-block-heading {
+    margin-bottom: 1rem;
+  }
+
+  h4.wp-block-heading {
+    margin-bottom: 2rem;
+  }
+
+  ul.wp-block-list,
+  ol.wp-block-list {
+    margin-bottom: 2rem;
+    padding-left: 2rem;
+
+    li {
+      margin-bottom: 1rem;
+    }
+  }
+
+  h2.wp-block-heading {
+    margin-bottom: 2rem;
   }
 }

--- a/app/public/wp-content/themes/mooms_dev/theme/single-blog.php
+++ b/app/public/wp-content/themes/mooms_dev/theme/single-blog.php
@@ -12,10 +12,12 @@
 
 <div class="page aiot-blog" data-aos="fade-in" data-aos-duration="2000">
 	<div class="mm-container">
-		<?php theBreadcrumb() ?>
+		<div class="breadcrumb-top">
+			<?php theBreadcrumb() ?>
+		</div>
 		<div class="aiot-header">
 			<div class="aiot-title">
-				<?php the_title(); ?>		
+				<?php the_title(); ?>
 			</div>
 		</div>
 		<div class="aiot-content">


### PR DESCRIPTION
1. Chỉnh giãn hàng với khoảng cách cho thoáng
https://prnt.sc/zhyXa0AiN4HW 

2. Responsive xuống $md em cho nó hiện mũi tên ra (Anh Trí đề xuất)
https://prnt.sc/FL83y-ErMh52

3. Class breadcrumb-top: đẩy content cách header ra 6rem
https://prnt.sc/q6ZzNbPsu7Cc

4. Giãn cái gạch chân ra không gạch ngang chữ
https://prnt.sc/eoQHl63R6Zq2

5. Thêm khoảng cách giữa các dòng và thụt lề nội dung trong blog/
Cũ: https://prnt.sc/C4gT_qepDjAi
Đã sửa: https://prnt.sc/leKMZaTOvIiB

6. Bọc thẻ div để lấy khoảng cách
div class="breadcrumb-top">
	?php theBreadcrumb() ?>
/div>

7. Bỏ clamp đưa về responsive 

8. Đưa DX lên 1 hàng => ( sửa gap : -1 ở service )
https://prnt.sc/ZrcGSIl_FOO3